### PR TITLE
Add support for `allowed_classes`  optional parameter to unserialize

### DIFF
--- a/Analyzer/analyzer.py
+++ b/Analyzer/analyzer.py
@@ -386,6 +386,10 @@ class Analyzer:
             f.write(b'?>')
         self.target_file_list = self.s_analyzer.parse_file(EVAL_FILE)
 
+        # If PHP returns an empty array, Python treats it as a list.
+        if isinstance(user_classes, list):
+            user_classes = {}
+
         target_class, target_function = \
                         self.d_analyzer.update_info(user_classes,
                                                     user_functions,
@@ -1153,6 +1157,11 @@ class Analyzer:
         class_list = []
 
         declared_flag = False
+
+        # If PHP returns an empty array, Python treats it as a list.
+        if isinstance(user_classes, list):
+            user_classes = {}
+
         for class_name, class_info in user_classes.items():
             if not re.match(EXCLUDED_CLASSES_REGEX, class_name) and \
                class_info['FILE_NAME'].startswith(self.target):

--- a/Analyzer/dynamic.py
+++ b/Analyzer/dynamic.py
@@ -124,6 +124,9 @@ class DynamicAnalyzer:
                 new_func_info['FILE_NAME'] = func_file
                 target_function[func_name] = new_func_info
 
+        if not user_classes:
+            return target_class, target_function
+
         for class_name, class_info in user_classes.items():
             if not re.match(EXCLUDED_CLASSES_REGEX, class_name):
                 file_name = class_info['FILE_NAME']

--- a/Analyzer/dynamic.py
+++ b/Analyzer/dynamic.py
@@ -124,8 +124,9 @@ class DynamicAnalyzer:
                 new_func_info['FILE_NAME'] = func_file
                 target_function[func_name] = new_func_info
 
-        if not user_classes:
-            return target_class, target_function
+        # If PHP returns an empty array, Python treats it as a list.
+        if isinstance(user_classes, list):
+            user_classes = {}
 
         for class_name, class_info in user_classes.items():
             if not re.match(EXCLUDED_CLASSES_REGEX, class_name):

--- a/Files/sensitive_functions_list.txt
+++ b/Files/sensitive_functions_list.txt
@@ -2,7 +2,6 @@
 
 
 unserialize|1
-fugio_unserialize|1
 # ==== NEED TO SET VULN INJECT POINT NUMBERS!! ====
 copy|1
 file_exists|1

--- a/Files/sensitive_functions_list.txt
+++ b/Files/sensitive_functions_list.txt
@@ -2,6 +2,7 @@
 
 
 unserialize|1
+fugio_unserialize|1
 # ==== NEED TO SET VULN INJECT POINT NUMBERS!! ====
 copy|1
 file_exists|1

--- a/Utils/HookFiles/HookHead.php
+++ b/Utils/HookFiles/HookHead.php
@@ -290,7 +290,7 @@ function get_declared_traits_r353t() {
 
 function filter_allowed_classes($array, $trigger_func, $func_argv) {
   $return_array = $array;
-  if ($trigger_func == "unserialize" && count($func_argv) > 1) {
+  if (($trigger_func == "unserialize" || $trigger_func == "fugio_unserialize") && count($func_argv) > 1) {
       if (array_key_exists("allowed_classes", $func_argv[1])) {
           if (gettype($func_argv[1]["allowed_classes"]) == "boolean") {
               if ($func_argv[1]["allowed_classes"] == false) {

--- a/Utils/HookFiles/HookHead.php
+++ b/Utils/HookFiles/HookHead.php
@@ -290,7 +290,7 @@ function get_declared_traits_r353t() {
 
 function filter_allowed_classes($array, $trigger_func, $func_argv) {
   $return_array = $array;
-  if (($trigger_func == "unserialize" || $trigger_func == "fugio_unserialize") && count($func_argv) > 1) {
+  if ($trigger_func == "unserialize" && count($func_argv) > 1) {
       if (array_key_exists("allowed_classes", $func_argv[1])) {
           if (gettype($func_argv[1]["allowed_classes"]) == "boolean") {
               if ($func_argv[1]["allowed_classes"] == false) {


### PR DESCRIPTION
The PHP `unserialize` function can take an optional parameter `allowed_classes` to restrict the set of allowed classes that can be deserialized (https://www.php.net/manual/en/function.unserialize.php). When an application has a restricted set of allowed classes at an unserialize call site, an exploit can only use gadgets from the set of allowed classes.

We extended FUGIO to support the semantics of the `allowed_classes` optional parameter. 

This was necessary to evaluate [our mitigation](https://figshare.com/articles/software/QUACK_Hindering_Deserialization_Attacks_via_Static_Duck_Typing/24578644) for deserialization vulnerabilities that automatically determines a correct set of `allowed_classes`, and we hope that it can benefit other researchers in the future.